### PR TITLE
Inspect argument values for multiple invocations of the same function

### DIFF
--- a/src/jack.js
+++ b/src/jack.js
@@ -392,7 +392,8 @@ function jack() {} // This needs to be here to make error reporting work correct
 			}
 		}
 		function getArguments() {
-			return invocations[0].getArgumentValues();
+			var invocation = arguments[0] ? arguments[0] : 0;
+			return invocations[invocation].getArgumentValues();
 		}
 	} // END FunctionGrab()
 

--- a/test/test_02_saving_arguments.js
+++ b/test/test_02_saving_arguments.js
@@ -30,4 +30,26 @@ describe('Saving arguments', {
 		
 		window.globalFunction = null;
 	}
+	,
+	'Should be able to inspect argument values for multiple invocations of the same function': function() {
+		window.globalFunction = function(arg1, arg2) {}
+		
+		jack(function(){
+			jack.expect("globalFunction").exactly("2 times");
+			globalFunction("value1", 7740923, {message:'Kilroy was here!'});
+			globalFunction("value2", 1234567, {message:'Jack was here!'});
+		});
+		
+		var firstInvocation = jack.inspect("globalFunction").arguments(0);
+		value_of(firstInvocation[0]).should_be("value1");
+		value_of(firstInvocation[1]).should_be(7740923);
+		value_of(firstInvocation[2]).should_be({message:'Kilroy was here!'});
+		
+		var secondInvocation = jack.inspect("globalFunction").arguments(1);
+		value_of(secondInvocation[0]).should_be("value2");
+		value_of(secondInvocation[1]).should_be(1234567);
+		value_of(secondInvocation[2]).should_be({message:'Jack was here!'});
+
+		window.globalFunction = null;
+	}
 });


### PR DESCRIPTION
Hi,
I came across a problem today that required that I inspect the arguments passed into a function that is called multiple times. However, I found that Jack was only able to inspect the first instance of a function call as the "getArguments()" function contained a hard-coded value.

This commit allows you to select which function invocation to inspect. I've also added a test that describes the change.

Thanks for the great work on jack, it's continuing to prove very useful.
Peter.
